### PR TITLE
Fix KreweConnect login button doing nothing on click

### DIFF
--- a/src/components/CippCards/CippImageCard.jsx
+++ b/src/components/CippCards/CippImageCard.jsx
@@ -2,6 +2,13 @@ import NextLink from "next/link";
 import ArrowRightIcon from "@heroicons/react/24/outline/ArrowRightIcon";
 import { Box, Button, LinearProgress, Skeleton, Stack, SvgIcon, Typography } from "@mui/material";
 
+// Links that aren't Next.js routes (auth/platform endpoints, absolute URLs) must
+// trigger a full-page browser navigation. Routing them through NextLink results in
+// a client-side transition to a non-existent route, so the click appears to do nothing.
+const isExternalLink = (link) =>
+  typeof link === "string" &&
+  (/^(https?:)?\/\//.test(link) || link.startsWith("mailto:") || link.startsWith("/.auth/"));
+
 export const CippImageCard = ({
   isFetching,
   imageUrl = "/assets/illustration-reports.png",
@@ -52,7 +59,7 @@ export const CippImageCard = ({
       </Stack>
       {link && (
         <Button
-          component={NextLink}
+          {...(isExternalLink(link) ? { component: "a" } : { component: NextLink })}
           endIcon={
             <SvgIcon fontSize="small">
               <ArrowRightIcon />


### PR DESCRIPTION
## Problem

On the KreweConnect login / access-denied page, clicking **Login** does nothing.

## Root cause

The login page (`src/pages/unauthenticated.js`) points the Login button at the Azure Static Web Apps auth endpoint:

```
/.auth/login/aad?post_login_redirect_uri=...
```

That endpoint is handled by the SWA platform, **not** a Next.js page. However, `CippImageCard` rendered every link through `NextLink`:

```jsx
<Button component={NextLink} href={link} ... >
```

`NextLink` intercepts the click and performs a **client-side** route transition. Since `/.auth/login/aad` isn't a real app route, the Next.js router silently does nothing instead of navigating the browser to the auth endpoint — so the button appears dead.

The "Return to Home" variant (`link="/"`) worked because that *is* a real Next.js route.

## Fix

`CippImageCard` now detects external/platform links (`http(s)://`, `mailto:`, and `/.auth/`) and renders them as a plain `<a>` anchor (`component="a"`), forcing a real full-page browser navigation. Internal app routes continue to use `NextLink` for client-side navigation.

This fixes the Login button and any other external link routed through this shared card.

## Testing notes

Functional change is small and isolated to `CippImageCard`. Recommend verifying on a deployed SWA instance: from the access-denied page, click **Login** and confirm it now redirects to the AAD sign-in flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MvaB3pyQz4Ldx78hq9FNS

---
_Generated by [Claude Code](https://claude.ai/code/session_015MvaB3pyQz4Ldx78hq9FNS)_