### PR TITLE
Harden fork deploy: stop upstream auto-merge, least-privilege CI

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -2,7 +2,7 @@ version: "1"
 rules:
   - base: main
     upstream: KelvinTegelaar:main
-    mergeMethod: merge
+    mergeMethod: none
   - base: dev
     upstream: KelvinTegelaar:dev
     mergeMethod: none

--- a/.github/workflows/azure-static-web-apps-agreeable-stone-060c94b0f.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-stone-060c94b0f.yml
@@ -4,24 +4,22 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
+
+permissions:
+  contents: read
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
           lfs: false
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_STONE_060C94B0F }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
@@ -32,15 +30,3 @@ jobs:
           api_location: "" # Api source code path - optional
           output_location: "/out" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_STONE_060C94B0F }}
-          action: "close"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,23 +1,19 @@
 # Security Policy
 
-CIPPMS is a fork of [CIPP](https://github.com/KelvinTegelaar/CIPP) and is kept in
-sync with upstream. Where you report a vulnerability depends on where the flaw
-lives.
+## Supported Versions
+
+The current [release](https://github.com/KelvinTegelaar/CIPP/releases) is the only "supported version" and should not have any security bugs. However if you find a security issue in an older release feel free to also report this in case of regression, We'd rather know we made a mistake at one point in time and avoid that in the future.
 
 ## Reporting a Vulnerability
 
-**Issues specific to this fork** — its deploy workflow, fork-specific
-configuration, or its hosted deployment: open a private report from this
-repository's **Security → Report a vulnerability** tab
-(<https://github.com/tmabaker/CIPPMS/security/advisories/new>), or contact the
-repository owner directly. Please do not open a public issue for a suspected
-vulnerability.
+Reporting a vulnerability is best done by emailing [security@cyberdrain.com](mailto:security@cyberdrain.com?subject=CIPP%20Security%20Issue) but you can also message an admin directly on the CyberDrain Discord. All relevant contributors will be alerted and can discuss the issue in private and address it if appropriate. It will help in making the fix available as soon as possible without endangering other users of the product.
 
-**Issues in upstream CIPP code** — anything inherited from
-`KelvinTegelaar/CIPP`: report it to the upstream project under its own security
-policy (<https://github.com/KelvinTegelaar/CIPP/security/policy>, or email
-<security@cyberdrain.com>) so the fix reaches every downstream fork, then let us
-know so we can pull it in.
+We will publicly release any security report after the resolution, including all communications. If you would rather have only the bug report public, please let us know in the report.
 
-We will acknowledge valid reports, keep you updated on remediation, and
-coordinate disclosure once a fix is available.
+## Notifications and security advisories
+
+We report any security notification via the GitHub notification and advisory system. Sponsors that are hosted will also receive a notification in case a major bug has been found.
+
+## Bounties and Rewards
+
+This project is an open-source sponsorware effort, which makes it hard to create a monetary reward without breaking the bank very quickly. for *critical* level bugs, that cause RCE/API data leaks/etc I will award a 50 dollar reward. For other bugs, I potentially am able to reward with some swag such as an official CyberDrain T-shirt or hoodie :)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,19 +1,23 @@
 # Security Policy
 
-## Supported Versions
-
-The current [release](https://github.com/KelvinTegelaar/CIPP/releases) is the only "supported version" and should not have any security bugs. However if you find a security issue in an older release feel free to also report this in case of regression, We'd rather know we made a mistake at one point in time and avoid that in the future.
+CIPPMS is a fork of [CIPP](https://github.com/KelvinTegelaar/CIPP) and is kept in
+sync with upstream. Where you report a vulnerability depends on where the flaw
+lives.
 
 ## Reporting a Vulnerability
 
-Reporting a vulnerability is best done by emailing [security@cyberdrain.com](mailto:security@cyberdrain.com?subject=CIPP%20Security%20Issue) but you can also message an admin directly on the CyberDrain Discord. All relevant contributors will be alerted and can discuss the issue in private and address it if appropriate. It will help in making the fix available as soon as possible without endangering other users of the product.
+**Issues specific to this fork** — its deploy workflow, fork-specific
+configuration, or its hosted deployment: open a private report from this
+repository's **Security → Report a vulnerability** tab
+(<https://github.com/tmabaker/CIPPMS/security/advisories/new>), or contact the
+repository owner directly. Please do not open a public issue for a suspected
+vulnerability.
 
-We will publicly release any security report after the resolution, including all communications. If you would rather have only the bug report public, please let us know in the report.
+**Issues in upstream CIPP code** — anything inherited from
+`KelvinTegelaar/CIPP`: report it to the upstream project under its own security
+policy (<https://github.com/KelvinTegelaar/CIPP/security/policy>, or email
+<security@cyberdrain.com>) so the fix reaches every downstream fork, then let us
+know so we can pull it in.
 
-## Notifications and security advisories
-
-We report any security notification via the GitHub notification and advisory system. Sponsors that are hosted will also receive a notification in case a major bug has been found.
-
-## Bounties and Rewards
-
-This project is an open-source sponsorware effort, which makes it hard to create a monetary reward without breaking the bank very quickly. for *critical* level bugs, that cause RCE/API data leaks/etc I will award a 50 dollar reward. For other bugs, I potentially am able to reward with some swag such as an official CyberDrain T-shirt or hoodie :)
+We will acknowledge valid reports, keep you updated on remediation, and
+coordinate disclosure once a fix is available.


### PR DESCRIPTION
Draft — part of a cross-repo security review. Only **owner-specific** files are touched (not upstream source) to avoid perpetual pull[bot] conflicts.

## Changes
- **`.github/pull.yml` — `main` sync set to `mergeMethod: none`.** pull[bot] now opens a review PR for upstream `KelvinTegelaar:main` syncs instead of auto-merging straight into the branch that auto-deploys to production. This restores a human review gate on a multi-tenant-privileged app. (`dev` was already `none`; `website` left as-is.)
- **Fork's SWA deploy workflow hardened** — added `permissions: { contents: read }`; SHA-pinned `actions/checkout` (upgraded from deprecated `@v3`) and `Azure/static-web-apps-deploy`; removed the `pull_request` trigger + `close_pull_request_job` (they only red-failed on pull[bot] PRs, which get no secrets). The `push: [main]` deploy job is preserved.

## Not changed (flagged for out-of-band handling)
Editing these upstream-inherited files here would fight pull[bot] every sync — handle on a non-conflicting path or by auditing the live Azure resources:
- `deployment/AzureDeploymentTemplate.json` (+ Dev variant): `GithubToken` → `securestring`; storage `apiVersion` bump + HTTPS-only/TLS1.2/no-public-blob; Key Vault policy `secrets:["all"]` → least-privilege; function MSI is Contributor over the whole RG.
- Permissive upstream CSP in `staticwebapp.config.json` (`unsafe-eval`/`unsafe-inline`, `img-src *`).
- `SECURITY.md` is intentionally left as upstream CIPP's real policy.

## Owner follow-ups
Enable secret scanning + push protection + Dependabot (off by default on forks); add branch protection on `main`; add a sync-health monitor that alerts if the fork falls behind upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oHE8cMgovLg83PA5J9FbU

---
_Generated by [Claude Code](https://claude.ai/code/session_016oHE8cMgovLg83PA5J9FbU)_